### PR TITLE
Update charter.html

### DIFF
--- a/docs/charter.html
+++ b/docs/charter.html
@@ -34,7 +34,7 @@
       [DRAFT] SPARQL 1.2 Community Group Charter
     </h1>
     <p>
-      This Charter is work in progress. 
+      This Charter is a work in progress. 
       To submit feedback, please use 
       <a href="https://github.com/w3c/sparql-12/issues">GitHub repository Issues</a>
       where the Charter is being developed.
@@ -46,7 +46,7 @@
       </li>
       <li>Start Date: ? April 2019
       </li>
-      <li>Last Modifed: ? April 2019
+      <li>Last Modified: ? April 2019
       </li>
     </ul>
     <h2 id="goals">
@@ -111,8 +111,8 @@
       Non-Normative Reports
     </h3>
     <p>
-      The group will produce reports that describes possible features for
-      consideration by a future SPARQL Working Group. This may include use cases and
+      The group will produce reports that describe possible features for
+      consideration by a future SPARQL Working Group. These may include use cases and
       requirements, technical descriptions, and implementation experience.
     </p>
     <h3 id="test-suites">
@@ -222,8 +222,8 @@
       Decision Process
     </h2>
     <p>
-      This group will seek to make decisions where there is consensus. Groups
-      are free to decide how to make decisions (e.g. Participants who have
+      This group will seek to make decisions through consensus. Groups
+      are free to decide how to make decisions (e.g., Participants who have
       earned Committer status for a history of useful contributions assess
       consensus, or the Chair assesses consensus, or where consensus isn't
       clear there is a Call for Consensus [CfC] to allow multi-day online
@@ -234,7 +234,7 @@
       recorded (where GitHub is used as the resolution of an Issue).
     </p>
     <p>
-      If substantial disagreement remains (e.g. the group is divided) and the
+      If substantial disagreement remains (e.g., the group is divided) and the
       group needs to decide an Issue in order to continue to make progress, the
       Committers will choose an alternative that had substantial support (with
       a vote of Committers if necessary). Individuals who disagree with the
@@ -255,7 +255,7 @@
     </p>
     <p>
       It is the Chairs' responsibility to ensure that the decision process is
-      fair, respects the consensus of the CG, and does not unreasonably favour
+      fair, respects the consensus of the CG, and does not unreasonably favor
       or discriminate against any group participant or their employer.
     </p>
     <h2 id="chairs">
@@ -279,7 +279,7 @@
       <li>Participants vote. Participants have 21 days to vote for a single
       candidate, but this period ends as soon as all participants have voted.
       The individual who receives the most votes, no two from the same
-      organisation, is elected chair. In case of a tie, RFC2777 is used to
+      organization, is elected chair. In case of a tie, RFC2777 is used to
       break the tie. An elected Chair may appoint co-Chairs.
       </li>
     </ol>
@@ -303,7 +303,7 @@
       as deliverable dates by the simpler group decision process rather than
       this charter amendment process. The group will use the amendment process
       for any substantive changes to the goals, scope, deliverables, decision
-      process or rules for amending the charter.
+      process, or rules for amending the charter.
     </p>
   
 


### PR DESCRIPTION
* punctuation and spelling corrections (note -- W3 officially uses [U.S. English](https://www.w3.org/2001/06/manual/#Spelling))
* a couple of minor word changes

I would have done this pre-vote-call, but there was not clear advance notice that the vote was being called.
