### PR TITLE
w3c/sparql-12#101 SEP-0003 for re-introducing min/max

### DIFF
--- a/SEP/SEP-0003/sep-0003.md
+++ b/SEP/SEP-0003/sep-0003.md
@@ -22,7 +22,7 @@ The functionality of limited connectivity checks is still valid with non-countin
 
 ## Motivation
 
-As raised in [sparql-12#101](https://github.com/w3c/sparql-12/issues/101), it would be nice to have this functionaliy available in SPARQL 1.2.
+As raised in [sparql-12#101](https://github.com/w3c/sparql-12/issues/101), it would be nice to have this functionality available in SPARQL 1.2.
 
 Pragmatically many stores already implement the form `{,max}` as the `*` and `+` versions are implicetly limited.
 
@@ -41,4 +41,3 @@ An alternative is that this could be reintroduces with counting semantics.
 This proposal is purely additive to SPARQL 1.1.
 
 ## Tests and implementations
-

--- a/SEP/SEP-0003/sep-0003.md
+++ b/SEP/SEP-0003/sep-0003.md
@@ -1,0 +1,44 @@
+# Property paths with a min/max hop
+
+* Short Name: min-max-propery-path
+* SEP Number: [SEP-0003](sep-0003.md)
+* Author: [Jerven Bolleman](https://github.com/jervenbolleman)
+
+## Abstract
+
+In the SPARQL 1.1. working group, a form of bounded property path where supported in the late [drafts](https://www.w3.org/TR/2012/WD-sparql11-query-20120105/#propertypaths). The form being a path element _elt_, followed by a curly bracket enclosed min/max pattern.
+
+||Syntax Form||Matches||
+| _elt_{n,m} | A path of between n and m occurrences of elt. |
+| _elt_{n}   | A path of exactly n occurrences of elt. |
+| _elt_{n,}  | A path of n or more occurrences of elt. |
+| _elt_{,n}  | A path of between 0 and n occurrences of elt. |
+
+This was removed in later draft and recommondation, upon the change to non-counting semantics.
+
+> Such connectivity matching does not introduce duplicates (it does not incorporate any count of the number of ways the connection can be made) even if the repeated path itself would otherwise result in duplicates. 
+
+The functionality of limited connectivity checks is still valid with non-counting semantics, in pragmatic terms. 
+
+## Motivation
+
+As raised in [sparql-12#101](https://github.com/w3c/sparql-12/issues/101), it would be nice to have this functionaliy available in SPARQL 1.2.
+
+Pragmatically many stores already implement the form `{,max}` as the `*` and `+` versions are implicetly limited.
+
+## Rationale and Alternatives
+
+An alternative is that this could be reintroduces with counting semantics.
+
+## Evidence of consensus
+
+**TODO: To be filled in when/if such evidence becomes available**
+
+## Specification:
+
+## Backwards Compatibility
+
+This proposal is purely additive to SPARQL 1.1.
+
+## Tests and implementations
+

--- a/SEP/SEP-0003/sep-0003.md
+++ b/SEP/SEP-0003/sep-0003.md
@@ -24,7 +24,7 @@ The functionality of limited connectivity checks is still valid with non-countin
 
 As raised in [sparql-12#101](https://github.com/w3c/sparql-12/issues/101), it would be nice to have this functionality available in SPARQL 1.2.
 
-Pragmatically many stores already implement the form `{,max}` as the `*` and `+` versions are implicetly limited.
+Pragmatically many stores already implement the form `{,max}` as the `*` and `+` versions are implicitly limited.
 
 ## Rationale and Alternatives
 

--- a/SEP/SEP-0003/sep-0003.md
+++ b/SEP/SEP-0003/sep-0003.md
@@ -8,7 +8,8 @@
 
 In the SPARQL 1.1. working group, a form of bounded property path where supported in the late [drafts](https://www.w3.org/TR/2012/WD-sparql11-query-20120105/#propertypaths). The form being a path element _elt_, followed by a curly bracket enclosed min/max pattern.
 
-||Syntax Form||Matches||
+|Syntax Form|Matches|
+|-----------|-----------|
 | _elt_{n,m} | A path of between n and m occurrences of elt. |
 | _elt_{n}   | A path of exactly n occurrences of elt. |
 | _elt_{n,}  | A path of n or more occurrences of elt. |


### PR DESCRIPTION
Re-Introduce the property path min-max syntax in a non counting form.

```sparql
SELECT 
  ?x
  ?y
WHERE {
 ?x rdfs:subClassOf{1,100} ?y .
}
```