### PR TITLE
Fix language and markup

### DIFF
--- a/SEP/SEP-0007/sep-0007.md
+++ b/SEP/SEP-0007/sep-0007.md
@@ -9,12 +9,12 @@
 
 ## Abstract
 
-EXISTS/NOT EXISTS relies on the 
+`EXISTS`/`NOT EXISTS` relies on the
 ["substitute" operation](https://www.w3.org/TR/sparql11-query/#defn_substitute).
 
 There are several problems identified with the specification material.
 
-Substitute is also used in [LATERAL Join](sep-0006.md).
+Substitute is also used in [`LATERAL` Join](sep-0006.md).
 
 This SEP describes the issues and proposes solutions.
 
@@ -26,12 +26,12 @@ The SPARQL 1.1 algebra operation [`substitute`](https://www.w3.org/TR/sparql11-q
 pattern where there are specific values for variables given by a solution mapping.
 The operation is used in the evaluation of `EXISTS` and `NOT EXISTS` operations.
 
-A simlar operation is needed for a `LATERAL` join - both are exposing the specific values for
-variables row-by-row from part of the query evaluation into a graph pattern.
+A similar operation is needed for a `LATERAL` join. Both are exposing the specific values for
+variables, row-by-row, from part of the query evaluation into a graph pattern.
 
-This document list problems that have been identified with the `substitute` operation and proposes an improved substitution evaluation
+This document lists problems that have been identified with the `substitute` operation, and proposes an improved substitution evaluation
 process that addresses these problems based on the concept of
-[Correlated Subquery](https://en.wikipedia.org/wiki/Correlated_subquery) found in SQL.
+[Correlated Subquery](https://en.wikipedia.org/wiki/Correlated_subquery) as found in SQL.
 
 * [Summary](#summary)
 * [Identified Issues](#identified-issues)
@@ -40,16 +40,16 @@ process that addresses these problems based on the concept of
 * [Notes](#notes)
 
 ## Summary
-The fundamental problem is that a variable can not be simply replaced by a value
+The fundamental problem is that a variable cannot be simply replaced by a value
 (an RDF Term) in all places in a graph pattern. There are some places where
-SPARQL function forms and `AS` assignment require a variable. The proposal here
+SPARQL function forms and `AS` assignments require a variable. The proposal here
 is to take the variable binding from the input solution, retaining the
 variable in the graph pattern, and disallowing cases that can reset the variable
-binding as is already the case elsewhere in SPARQL.
+binding, as is already the case elsewhere in SPARQL.
 
 ## Identified Issues
 This section describes the issues identified on the
-SPARQL Exists Community group mailing list [public-sparql-exists/2016Jul/0014](https://lists.w3.org/Archives/Public/public-sparql-exists/2016Jul/0014.html).
+SPARQL `Exists` Community group mailing list [public-sparql-exists/2016Jul/0014](https://lists.w3.org/Archives/Public/public-sparql-exists/2016Jul/0014.html).
 
 * [Some uses of `EXISTS` are not defined during evaluation.](#issue-1-some-uses-of-exists-are-not-defined-during-evaluation))
 * [Substitution happens where definitions are only for variables.](#issue-2-substitution-happens-where-definitions-are-only-for-variables)
@@ -58,8 +58,8 @@ SPARQL Exists Community group mailing list [public-sparql-exists/2016Jul/0014](h
 * [Substitution affects disconnected variables.](#issue-5-substitution-affects-disconnected-variables)
 
 ### Issue 1: Some uses of `EXISTS` are not defined during evaluation
-The evaluation process in the specificiation is defined for graph patterns but
-there are situations where the evaluation is of an alegbra form not listed.
+The evaluation process in the specification is defined for graph patterns, but
+there are situations where the evaluation is of an unlisted algebra form.
 
 For example:
 
@@ -76,14 +76,14 @@ FILTER EXISTS { VALUES ?y { 123 } }
 The argument to [`EXISTS`](https://www.w3.org/TR/sparql11-query/#defn_evalExists)
 is not explicitly listed as a `Graph Pattern` in the table of SPARQL algebra symbols in
 [section 18.2](https://www.w3.org/TR/sparql11-query/#sparqlQuery)
-when the argument to `EXISTS` is a [GroupGraphPattern](https://www.w3.org/TR/sparql11-query/#rGroupGraphPattern)
+where the argument to `EXISTS` is listed as a [GroupGraphPattern](https://www.w3.org/TR/sparql11-query/#rGroupGraphPattern)
 containing just a [subquery](https://www.w3.org/TR/sparql11-query/#subqueries)
 or just [InlineData](https://www.w3.org/TR/sparql11-query/#inline-data).
 
 ### Issue 2: Substitution happens where definitions are only for variables
 
 There are places in the SPARQL syntax and algebra where
-variables are allowed but not RDF terms (constant values).
+variables are allowed, but RDF terms (constant values) are not.
 
 Example:
 
@@ -96,32 +96,32 @@ FILTER EXISTS { BIND ( :e AS ?z )
 Both positions `AS ?z` and `SELECT ?x` must be variables.
 
 In the algebra, this affects
- * [`extend`](https://www.w3.org/TR/sparql11-query/#defn_extend) (related to the use of `AS` in SPARQL syntax)
- * [in line data](https://www.w3.org/TR/sparql11-query/#inline-data) (related to the use of `VALUES`)
+ * [`extend`](https://www.w3.org/TR/sparql11-query/#defn_extend) which is related to the use of `AS` in SPARQL syntax
+ * [in line data](https://www.w3.org/TR/sparql11-query/#inline-data) which is related to the use of `VALUES`
  * [`BOUND`](https://www.w3.org/TR/sparql11-query/#func-bound)
 
 
 ### Issue 3: Blank nodes substituted into BGPs act as variables
 In the [evaluation of basic graph patterns](https://www.w3.org/TR/sparql11-query/#BasicGraphPattern)
-(BGPs) blank nodes
+(BGPs), blank nodes
 [are replaced](https://www.w3.org/TR/sparql11-query/#BGPsparql)
-by RDF terms from the graph being matched and variables are replaced by a solution
-mapping from query variables to RDF terms so that the  basic graph pattern is
+by RDF terms from the graph being matched, and variables are replaced by a solution
+mapping from query variables to RDF terms, so that the basic graph pattern is
 now a subgraph of the graph being matched.
 
-Simply substituting a variable with a blank node in the `EXISTS`
+Simply substituting a blank node for a variable in the `EXISTS`
 evaluation process does not cause the basic graph pattern to be
-to be restricted to subgraphs containing that blank node as an RDF term
+restricted to subgraphs containing that blank node as an RDF term,
 because it is mapped by an
 [RDF instance mapping](https://www.w3.org/TR/2004/REC-rdf-mt-20040210/#definst)
 before checking that the BGP after mapping is a subgraph of the
 graph being queried.
 
 Note that elsewhere in the evaluation of the SPARQL algebra, a solution
-mapping with a binding from variable to blank node, does treat blank nodes
+mapping with a binding from variable to blank node does treat blank nodes
 as RDF terms. They are not mapped by an RDF instance mapping.
 
-Example:
+For exampleExample:
 
 ```sparql
 SELECT ?x WHERE {
@@ -130,11 +130,11 @@ SELECT ?x WHERE {
 }
 ```
 
-against the graph `{ :c :p :d . :e :q :b }`
+against the graph `{ :c :p :d . :e :q :b }`,
 the substitution for `EXISTS` produces
-`BGP(:c :q :b)` which then
-matches against `:e :q :b` because the `_:c` can be mapped to `:e` by
-the RDF instance mapping that is part of pattern instance mappings in
+`BGP(:c :q :b)`, which then
+matches against `:e :q :b`, because the `_:c` can be mapped to `:e` by
+the RDF instance mapping that is part of the pattern instance mappings in
 [18.3.1](https://www.w3.org/TR/sparql11-query/#BGPsparql).
 
 ### Issue 4: Substitution can flip `MINUS` to its disjoint-domain case
@@ -148,15 +148,18 @@ SELECT ?x WHERE {
 }
 ```
 
-on the graph `{ :d :p :c }` the substitution from 18.6 ends up producing
+on the graph `{ :d :p :c }`, the substitution from
+[18.6](https://www.w3.org/TR/sparql11-query/#sparqlAlgebraEval)
+ends up producing
 
 ```
 Minus( BGP( :d :p :c ), BGP( :d :p :c ) )
 ```
 
-which produces a non-empty result because the two solution mappings for the
-`MINUS` have disjoint domains and 18.5 dictates that then the result is not
-empty.
+which produces a non-empty result, because the two solution mappings for the
+`MINUS` have disjoint domains, and
+[18.5](https://www.w3.org/TR/sparql11-query/#sparqlAlgebra)
+then dictates that the result is not empty.
 
 ### Issue 5: Substitution affects disconnected variables
 
@@ -170,7 +173,9 @@ SELECT ?x WHERE {
 }
 ```
 
-the substitution from 18.6 ends up producing
+the substitution from
+[18.6](https://www.w3.org/TR/sparql11-query/#sparqlAlgebraEval)
+ends up producing
 
 ```
   Join ( Extend( BGP(), ?z :e ),
@@ -179,49 +184,53 @@ the substitution from 18.6 ends up producing
        ))
 ```
 
-The `?x` inside the `SELECT ?y` is not projected out so it is a "different" `?x`
-than the outer one - changing it to another other unused name in the same query
+The `?x` inside the `SELECT ?y` is not projected out, so it is a "different" `?x`
+than the outer one; changing it to another other unused name in the same query
 would not normally affect the query results.
 
-## An Improved "substitute" Operation
-Evalauting
+## An Improved `substitute` Operation
+Evaluating
 [`substitute`](https://www.w3.org/TR/sparql11-query/#defn_substitute) is
-performed for a given solution mapping. For example, the `EXISTS` operation
-evaluates to `true` if a graph pattern has one or more matches given the variable bindings
-of a solution mapping. We call this solution mapping the *current row*
-in this description.
+performed for a given solution mapping. For example, if a graph pattern
+has one or more matches given the variable bindings of a solution mapping,
+the `EXISTS` operation evaluates to `true`. We call this solution mapping
+the *current row* in this description.
 
 This section proposes an alternative mechanism.  Rather than replace each
 variable by the value it is bound to in the current row, this alternative
 mechanism makes the whole of the current row available at any point in the
 evaluation of an `EXISTS` expression. It uses the current row to
-restrict the binding of variables at the points where variable bindings are
-created during evaluation of `EXISTS` to be those from the current row.
+restrict the binding of variables, at the points where variable bindings are
+created during evaluation of `EXISTS`, to be those from the current row.
 It makes illegal syntactic constructs that could lead to an attempt to rebind a
-variable from the current row through using the `AS` syntax.
+variable from the current row through the `AS` syntax.
 
 Section ["Addressing Issues"](#addressing-issues) describes how this alternative
 definition of `substitute` addresses each of the issues identified above.
 
 There are 3 parts to the proposal:
  
- * Place the current row mapping variables to values (the RDF terms) so that the variables always have their values from the current row.
-This is the replacement for syntactic substitution in the original definition.
- * Renaming inner scope variables so that variables that are only used within a
-sub-query are not affected by the current row. This reflects the fact that in
-SPARQL such variables are not present in solutions mappings outside their
-sub-query.
- * Disallow syntactic forms that set variables potentially already present in the current
-row. SPARQL solutions mappings can only have one binding for a variable and the
-current row provides that binding.
+1. Place the current row mapping variables to values (the RDF terms) so that the
+   variables always get their values from the current row.
+   This is the replacement for syntactic substitution in the original definition.
+2. Rename inner scope variables so that variables that are only used within a
+   sub-query are not affected by the current row. This reflects the fact that in
+   SPARQL such variables are not present in solution mappings outside their
+   sub-query.
+3. Disallow syntactic forms that set variables that may already be present in the
+   current row. SPARQL solution mappings can only have one binding for a variable,
+   and the current row provides that binding.
 
 ### Renaming
 
-Within sub-queries, variables with the same name can be used but do not
+Within sub-queries, variables with the same name can be used, but they do not
 appear in the overall results of the query if they do not occur in the
-projection in the sub-query. Such inner variables are not
-[in-scope](https://www.w3.org/TR/sparql11-query/#variableScope)
-when they are not in the output of the projection part of the inner SELECT expression.
+projection of the sub-query. Such inner variables are not
+[in-scope](https://www.w3.org/TR/sparql11-query/#variableScope) when they are
+not in the output of the projection part of the inner `SELECT` expression.
+
+Here, the `?s` is not mentioned in the projection of
+`SELECT (count(*) AS ?C)`:
 
 ```sparql
 SELECT * {
@@ -231,14 +240,13 @@ SELECT * {
            ?s :property ?w .
        } 
      }
-     FILTER ( ?C &lt; ?v )
+     FILTER ( ?C < ?v )
   }
 }
 ```
 
-Here, the `?s` is not mentioned in the projection in
-`SELECT (count(*) AS ?C)`. Replacing `?s` by, for example,
-`?V1234` in the sub-query does not change the overall results.
+Replacing `?s` in the sub-query with, for example,
+`?V1234` does not change the overall results:
 
 ```sparql
 SELECT * {
@@ -248,12 +256,12 @@ SELECT * {
              ?V1234 :property ?w .
        }
      }
-   FILTER ( ?C &lt; ?v )
+   FILTER ( ?C < ?v )
   }
 }
 ```
 
-Such variable usages can be replaced with a variable of a different name, if
+Such variables can be replaced with a variable of a different name, if
 that name is not used anywhere else in the query, and the same results are
 obtained in the sub-query. A sub-query always has a projection as its top-most
 algebra operator.
@@ -261,7 +269,7 @@ algebra operator.
 To preserve this, any such variables are renamed so they do not coincide with
 variables from the current row being filtered by `EXISTS`.
 
-The SPARQL algebra "project" operator has two components, an algebra expression
+The SPARQL algebra `project` operator has two components: an algebra expression,
 and a set of variables for the projection.
 
 <blockquote>
@@ -269,21 +277,23 @@ and a set of variables for the projection.
 <b>Definition: <a id="defn_projmap" name="defn_projmap">Projection Expression Variable Remapping</a></b>
 
   <p>
-For a projection algebra operation P with set of variables PV, define
-a partial mapping F from
-<a href="https://www.w3.org/TR/sparql11-query/#sparqlQueryVariables">V</a>,
-the set of all variables, to V where:
+For a projection algebra operation <code>P</code> with set of variables <code>PV</code>, define
+a partial mapping <code>F</code> from
+<a href="https://www.w3.org/TR/sparql11-query/#sparqlQueryVariables"><code>V</code></a>,
+the set of all variables, to <code>V</code> where:
 </p>
 <p class="defn-expr">
-F(v) = v if v in PV<br/>
-F(v) = v1 where v is a variable mentioned in the project expression
-       and v1 is a fresh variable<br/>
-F(v) = v otherwise.
+  <pre>
+    F(v) = v if v in PV
+    F(v) = v1 where v is a variable mentioned in the project expression
+           and v1 is a fresh variable
+    F(v) = v otherwise.
+</pre>
 </p>
-Define the <dfn>Projection Expression Variable Remapping</dfn> <tt>PrjMap(P,PV)</tt> to
-be the algebra expression P (and the subtree over which the projection is
-defined) with F applied to every variable of the algebra expression P over
-which P is evaluated.
+Define the <dfn>Projection Expression Variable Remapping</dfn> <code>PrjMap(P,PV)</code> to
+be the algebra expression <code>P</code> (and the subtree over which the projection is
+defined) with <code>F</code> applied to every variable of the algebra expression <code>P</code> over
+which <code>P</code> is evaluated.
 </div>
 </blockquote>
 
@@ -293,14 +303,17 @@ This process is applied throughout the graph pattern of `EXISTS`:
 <div class="defn">
 <b>Definition: <a id="defn_varrename" name="defn_varrename">Variable Remapping</a></b>
 <p>
-For any algebra expression X define the
-<dfn>Variable Remapping</dfn> PrjMap(X):
+For any algebra expression <code>X</code>, define the
+<dfn>Variable Remapping</dfn> <code>PrjMap(X)</code>:
 </p>
 <p class="defn-expr">
-PrjMap(X) = replace all project operations <tt>project(P PV)</tt> with <tt>project(PrjMap(P,PV) PV)</tt> for each projection in X.
+  <pre>
+    PrjMap(X) = replace all project operations project(P PV) 
+                with project(PrjMap(P,PV), PV) for each projection in X.
+</pre>
 </p>
 This replacement is applied bottom-up when there are multiple project
-operations in the graph pattern of <tt>EXISTS</tt>.
+operations in the graph pattern of <code>EXISTS</code>.
 </div>
 </blockquote>
 
@@ -310,22 +323,21 @@ variables not visible outside the sub-query. Renaming a variable in a SPARQL
 algebra expression causes the variable name used in bindings from evaluating the
 algebra expression to change. Since these are only variables that are not
 visible outside the sub-query, because they do not occur in the projection, the
-result of the sub-query is unchanged. SPARQL algebra expressions can not access
-the name of a variable nor introduce a variable except by remapping. Remapping
-is only applied to variables not visible outside the sub-query.
+result of the sub-query is unchanged. SPARQL algebra expressions cannot access
+the name of a variable nor introduce a variable except by remapping.
 
 ### Limitations on Assignment
 
 SPARQL syntactic forms that attempt to bind a variable through the use of
 `AS` that might already be in a solution mapping are forbidden in
-SPARQL: this is covered in the syntactic restrictions of
+SPARQL; this is covered in the syntactic restrictions of
 [19.8 Grammar](https://www.w3.org/TR/sparql11-query/#sparqlGrammar),
 notes 12 and 13.
 
 This proposal adds the restriction that any variables in a current
 row, the set of variables
 [in-scope](https://www.w3.org/TR/sparql11-query/#variableScope)
-of the expression containing EXISTS, can not be assigned with the `extend`
+of the expression containing `EXISTS`, cannot be assigned with the `extend`
 algebra function linked to the `AS` syntax.
 
 In addition, any use of `VALUES` in the `EXISTS` expression must not
@@ -334,48 +346,51 @@ use a variable in the current row.
 ### Restriction of Bindings
 
 The proposal is to retain the variables from the current row, not
-substitute them for RDF terms, before evaluation, and also to restrict
+substitute them for RDF terms before evaluation, and also to restrict
 the binding of the solution to the RDF term of the current row. This occurs
 after renaming.
 
-Binding for variables occur in several places in SPARQL:
+Binding for variables occurs in several places in SPARQL:
  
  * [Basic Graph Pattern Matching](https://www.w3.org/TR/sparql11-query/#BGPsparql)
  * [Property Path Patterns](https://www.w3.org/TR/sparql11-query/#PropertyPathPatterns)
- * [evaluation of algebra form `Graph(var,P)`](https://www.w3.org/TR/sparql11-query/#defn_evalGraph) involving a variable (from the syntax `GRAPH ?variable {&hellip;}`)
+ * [evaluation of algebra form `Graph(var,P)`](https://www.w3.org/TR/sparql11-query/#defn_evalGraph)
+   involving a variable (from the syntax `GRAPH ?variable {&hellip;}`)
  
 Note that other places where solution mappings add variables are in
-`extend` function (connected to the `AS` syntax)
+the `extend` function (connected to the `AS` syntax)
 and `a multiset` from `VALUES` syntax.
 [Limitations on Assignment](#limitations-on-assignment)
-forbid this being of variables of the current row.
+forbid these being variables of the current row.
 
 Restricting the RDF Terms for a variable binding is done using
-inline data that is joined with the evalaution of the basic graph pattern,
-property path or graph match.
+inline data that is joined with the evaluation of the basic graph pattern,
+property path, or graph match.
 
 <blockquote>
 <div class="defn">
 <b>Definition: <a id="defn_valuesinsertion" name="defn_valuesinsertion">Values Insertion</a></b>
 <p>
-For solution mapping μ, define Table(μ) to be the multiset formed from μ.
+For solution mapping <code>μ</code>, define <code>Table(μ)</code> to be the multiset formed from <code>μ</code>.
 </p>
 <p class="defn-expr">
-  Table(μ) = { μ }<br/>
-  Card[μ] = 1
+  <pre>
+    Table(μ) = { μ }
+    Card[μ] = 1
+</pre>
 </p>
 <p>
-  Define the <dfn>Values Insertion</dfn> function <tt>Replace(X, μ)</tt> to
-  replace each occurence Y of a 
+  Define the <dfn>Values Insertion</dfn> function <code>Replace(X, μ)</code> to
+  replace each occurence <code>Y</code> of a
   <a href="https://www.w3.org/TR/sparql11-query/#sparqlTranslateBasicGraphPatterns">Basic Graph Pattern</a>,
   <a href="https://www.w3.org/TR/sparql11-query/#sparqlTranslatePathExpressions">Property Path Expression</a>,
-  <a href="https://www.w3.org/TR/sparql11-query/#sparqlTranslateGraphPatterns">Graph(Var, pattern)</a>
-  in X with join(Y, Table(μ)).
+  <a href="https://www.w3.org/TR/sparql11-query/#sparqlTranslateGraphPatterns"><code>Graph(Var, pattern)</code></a>
+  in <code>X</code> with <code>join(Y, Table(μ))</code>.
 </p>
 </div>
 </blockquote>
 
-### Evaluation of EXISTS
+### Evaluation of `EXISTS`
 
 The evaluation of `EXISTS` is defined as:
 
@@ -383,13 +398,14 @@ The evaluation of `EXISTS` is defined as:
 <div class="defn">
 <b>Definition: <a id="defn_valuesinsertion" name="defn_valuesinsertion">Evaluation of Exists</a></b>
 <p>
-Let μ be the current solution mapping for a filter and X a graph pattern,
-define the <dfn>Evaluation of Exists</dfn> <tt>exists(X)</tt>
+Let <code>μ</code> be the current solution mapping for a filter, and <code>X</code> a graph pattern,
+define the <dfn>Evaluation of Exists</dfn> <code>exists(X)</code>
 </p>
 <p class="defn-expr">
-  exists(X) = true if eval(D(G), Replace(PrjMap(X), μ) is a non-empty solution sequence.
-  <br/>
-  exists(X) = false otherwise
+  <pre>
+    exists(X) = true if eval(D(G), Replace(PrjMap(X), μ) is a non-empty solution sequence.
+    exists(X) = false otherwise
+</pre>
 </p>
 </div>
 </blockquote>
@@ -400,14 +416,14 @@ This section addresses each issue identified, given the proposal above.
 
 ### Issue 1: Some uses of `EXISTS` are not defined during evaluation
 
-This can be handled by handling solution sequences as graph patterns where
-needed by adding
-[toMultiSet](https://www.w3.org/TR/sparql11-query/#defn_algToMultiSet)
-as is done for [SubSelect](https://www.w3.org/TR/sparql11-query/#rSubSelect)
+This can be addressed by handling solution sequences as graph patterns where
+needed, by adding
+[`toMultiSet`](https://www.w3.org/TR/sparql11-query/#defn_algToMultiSet)
+as is done for [`SubSelect`](https://www.w3.org/TR/sparql11-query/#rSubSelect)
 in [18.2.2.6 Translate Graph Patterns](https://www.w3.org/TR/sparql11-query/#sparqlTranslateGraphPatterns)
 with a a correction to the text at the end of
-[Section 18.2](https://www.w3.org/TR/sparql11-query/#sparqlQuery)
-introductory paragraph.
+the introductory paragraph of
+[Section 18.2](https://www.w3.org/TR/sparql11-query/#sparqlQuery).
 
 ```
 query-errata-N:
@@ -431,13 +447,13 @@ remains in the graph pattern of `EXISTS` and the evaluation.
 
 By making the current row, which can include blank nodes, available, and not
 modifying the BGP by substitution, no blank nodes are introduced into the
-evalaution of the BGP. Instead, the possible solutions is restricted by the
+evaluation of the BGP. Instead, the possible solutions are restricted by the
 current row.
 
 ### Issue 4: Substitution can flip `MINUS` to its disjoint-domain case
 
 Issue 4 is addressed because variables are not removed from the domain of
-`MINUS`. This propsoal does not preserve all uses of `MINUS`
+`MINUS`. This proposal does not preserve all uses of `MINUS`
 expressions; the problem identified in issue 4 is considered to be a bug in the
 SPARQL 1.1 specification.
 
@@ -446,11 +462,11 @@ SPARQL 1.1 specification.
 Issue 5 is addressed by noting that variables inside sub-queries which are not
 projected can be renamed without affecting the sub-query results. Whether to
 preserve that invariant or allow the variables to be set by the current row is a
-choice point - this design preserves the independence of disconnected variables.
+choice point; this design preserves the independence of disconnected variables.
 
 ## Notes
 
-The proposal described in this document does not cover use of variables from
+The proposal described in this document does not cover the use of variables from
 the current row in a `HAVING` clause.
 
 ### Notes


### PR DESCRIPTION
This PR takes language fixes from #174, and also fixes up the definition blocks which had become broken somewhere between the original material and the current state.

The definition blocks fix-ups are hardly perfect, but some of the original markup which would apply the SPARQL spec styling has been lost and so it is now possible the blocks need to be reset. There isn't much point spending too much time of them.