### PR TITLE
Update sep-0007.md

### DIFF
--- a/SEP/SEP-0007/sep-0007.md
+++ b/SEP/SEP-0007/sep-0007.md
@@ -130,9 +130,9 @@ SELECT ?x WHERE {
 }
 ```
 
-against the graph `{ :c :p :d . :e :q :b }`,
+against the graph `{ _:c :p :d . :e :q :b }`,
 the substitution for `EXISTS` produces
-`BGP(:c :q :b)`, which then
+`BGP(_:c :q :b)`, which then
 matches against `:e :q :b`, because the `_:c` can be mapped to `:e` by
 the RDF instance mapping that is part of the pattern instance mappings in
 [18.3.1](https://www.w3.org/TR/sparql11-query/#BGPsparql).


### PR DESCRIPTION
the `:c` term in the graph would need to be `_:c` - that is, a blank node, for it to have the described effect in connection with the "substitution" mechanism.