### PR TITLE
docs: Comunica implements SEP 0002

### DIFF
--- a/SEP/SEP-0002/sep-0002.md
+++ b/SEP/SEP-0002/sep-0002.md
@@ -111,6 +111,7 @@ This proposal is purely additive to SPARQL 1.1.
 * [Tests][tests]
 * Implementations:
     * [Kineo][kineo-sparql-12] (sparql-12 branch)
+    * [Comunica](https://github.com/comunica/comunica) (Excluding the ADJUST function)
 
 [xpfo]: https://www.w3.org/TR/xpath-functions-31/#dateTime-arithmetic
 [odt]: https://www.w3.org/TR/sparql11-query/#operandDataTypes


### PR DESCRIPTION
I would like to add Comunica to the list of implementations of SEP 0002.

Related proof of the implementation:
* https://github.com/comunica/sparqlee/pull/163
* https://github.com/comunica/comunica/pull/1202